### PR TITLE
fix: windows support

### DIFF
--- a/src/ofxGlobalContext2.h
+++ b/src/ofxGlobalContext2.h
@@ -9,7 +9,11 @@
 #define GlobalContext2_h
 #include <type_traits>
 #include <typeinfo>
+
+#ifndef _WIN32
 #include <cxxabi.h>
+#endif
+
 #include <string>
 #include <stdlib.h>
 #include <map>


### PR DESCRIPTION
Working on Windows. I don't know `cxxabi.h` is really needed on also other platforms, so please consider this PR is valid.